### PR TITLE
Compatibility fixes for command-line-definer macro

### DIFF
--- a/macros.dylan
+++ b/macros.dylan
@@ -283,7 +283,7 @@ define macro defcmdline-class
              = begin
                  let names = ?names;
                  make(?kind,
-                      names: if (names == #f) #( ?"option" ) else names end,
+                      names: names | #( ?"option" ),
                       ?default,
                       ?initargs);
                end; ... }

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -278,7 +278,5 @@ define test test-defcmdline ()
 end test test-defcmdline;
 
 // Prevent warnings for unused defs.
-begin
-  log-filename;
-  other;
-end;
+ignore(log-filename);
+ignore(other);


### PR DESCRIPTION
This does change the syntax of the macro.
