### PR TITLE
Allow -h to work with invalid positional args.

### DIFF
--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -269,6 +269,7 @@ define test test-min-max-positional-options ()
   assert-no-errors(parse-command-line(parser, #["a"]), "abc");
   assert-no-errors(parse-command-line(parser, #["a", "b"]), "xxx");
   assert-signals(<usage-error>, parse-command-line(parser, #["a", "b", "c"]), "yyy");
+  assert-signals(<help-requested>, parse-command-line(parser, #["-h"]));
 end test test-min-max-positional-options;
 
 define suite command-line-parser-test-suite


### PR DESCRIPTION
Fixes #12.

* command-line-parser.dylan
  (parse-command-line): Pass usage and description to %parse-command-line
    and let that function handle printing the synopsis when requested.
    Also, only print the ``<usage-error>`` if it isn't a ``<help-requested>``.
  (%parse-command-line): Print the synopsis when requested.

* tests/command-line-parser-test-suite.dylan
  (test-min-max-positional-options): Add test to be sure that help is
    handled, despite invalid positional args.