### PR TITLE
Add support for subcommands

### DIFF
--- a/command-line-parser.dylan
+++ b/command-line-parser.dylan
@@ -668,7 +668,7 @@ define function %parse-command-line
         parse-option(option, parser);
         option.option-present? := #t;
       otherwise =>
-        parser-error("Unrecognized token type: %=", token);
+        parser-error("Unexpected token: %=", token.token-value);
     end select;
   end while;
 

--- a/command-line-parser.dylan
+++ b/command-line-parser.dylan
@@ -29,11 +29,6 @@ copyright: See LICENSE file in this distribution.
 //  All the tokens on that command line are arguments. "-x" and "--y"
 //  are options, and "bar" is a parameter. "baz" is a positional argument.
 
-// todo -- There is no error signalled if two options have the same short name
-//         (or long name, I assume).  In fact there's a comment saying that the
-//         rightmost argument with the same name takes precedence.  So this is
-//         by design???
-//
 // todo -- There is no indication of default values in the generated synopsis,
 //         and the syntax for specifying "syntax" and docstring is bizarre at
 //         best.  --cgay 2006.11.27
@@ -47,9 +42,6 @@ copyright: See LICENSE file in this distribution.
 // TODO(cgay): This error sucks: "<unknown-option>" is not present as
 // a key for {<string-table>: size 12}.  How about "<unknown-option>
 // is not a recognized command-line option."  See next item.
-
-// TODO(cgay): Export usage-error and <usage-error> after fixing them
-// up.  These are duplicated in testworks, so use them there.
 
 // TODO(cgay): With an option that has negative options (e.g.,
 // --verbose and --quiet in the same option) just show the positive

--- a/command-line-parser.dylan
+++ b/command-line-parser.dylan
@@ -59,8 +59,15 @@ copyright: See LICENSE file in this distribution.
 // note like "Use --helpall to list all options."
 
 // TODO(cgay): (Related to above.)  Add a way to group options together
-// so that there can be a heading above each group.  For example,
-// "Logging options:".
+// so that there can be a heading above each group. Probably a `group`
+// slot on the <option> class.
+
+// TODO(cgay): Add a way to specify that several options are mutually
+// exclusive.
+
+// TODO(cgay): It might be worth exploring the separation of the parser
+// from the description of the command line. Some of the naming would
+// be clarified.
 
 //======================================================================
 //  Errors
@@ -69,142 +76,271 @@ copyright: See LICENSE file in this distribution.
 define open class <command-line-parser-error> (<format-string-condition>, <error>)
 end;
 
-// For when the user provides an invalid command-line.
-// These errors will be displayed to the user via condition-to-string.
-define open class <usage-error> (<command-line-parser-error>)
+// The one condition that we expect user code to handle around calls to
+// parse-command-line and execute-command. Signaled by the help mechanism
+// to exit the command with status 0.
+define class <abort-command-error> (<command-line-parser-error>)
+  constant slot exit-status :: <integer>, required-init-keyword: status:;
 end;
 
-// This isn't quite right, but it gives callers a way to handle
-// the case where we would normally call exit-application.  See
-// comment in parse-command-line for details.
-define class <help-requested> (<usage-error>)
+define not-inline function abort-command
+    (status :: <integer>) => ()
+  error(make(<abort-command-error>, status: status));
 end;
 
-// Making this inline stifles return type warnings.
-define inline function usage-error
-    (format-string :: <string>, #rest format-args) => ()
+define open class <usage-error> (<abort-command-error>)
+end;
+
+define not-inline function usage-error
+    (format-string :: <string>, #rest format-args)
   error(make(<usage-error>,
+             status: 2,
              format-string: format-string,
              format-arguments: format-args))
-end;
+end function;
 
-// Making this inline stifles return type warnings.
-define inline function parser-error
-    (format-string :: <string>, #rest format-args) => ()
+// For incorrect usage of the library interface.
+define not-inline function parser-error
+    (format-string :: <string>, #rest format-args)
   error(make(<command-line-parser-error>,
              format-string: format-string,
              format-arguments: format-args))
-end;
+end function;
 
 
 //======================================================================
-//  <command-line-parser>
+//  <command> and subclasses
 //======================================================================
 
-define open class <command-line-parser> (<object>)
-  // Retained across calls to parse-command-line.
-  slot option-parsers :: <stretchy-vector> /* of <option> */ =
-    make(<stretchy-vector> /* of <option> */);
+define abstract class <command> (<object>)
+  constant slot parser-tokens :: <deque> = make(<deque>); // of: <token>
+  slot command-options :: <sequence> = make(<stretchy-vector>),
+    init-keyword: options:;
+  constant slot %command-help :: <string>,
+    required-init-keyword: help:;
+end class;
 
-  constant slot tokens :: <deque> /* of: <token> */ =
-    make(<deque> /* of: <token> */);
+define method initialize (cmd :: <command>, #key) => ()
+  next-method();
+  validate-options(cmd.command-options);
+end method;
 
-  slot positional-arguments :: <stretchy-vector> /* of <string> */
-    = make(<stretchy-vector>);
-  constant slot min-positional-arguments :: <integer> = 0,
-    init-keyword: min-positional-arguments:;
-  constant slot max-positional-arguments :: <integer> = $maximum-integer,
-    init-keyword: max-positional-arguments:;
-
-  // Whether to automatically handle --help for the client.
-  constant slot provide-help-option? :: <boolean> = #t,
-    init-keyword: provide-help-option?:;
-  constant slot help-option :: <flag-option>
-    = make(<flag-option>,
-           names: #("help", "h"),
-           help: "Display this message."),
-    init-keyword: help-option:;
-end class <command-line-parser>;
-
-// For temporary backward compatibility.
-define constant positional-options = positional-arguments;
-
-define open generic reset-parser
-    (parser :: <command-line-parser>) => ();
-
-// Why? Why not just make a new one?
-define method reset-parser
-    (parser :: <command-line-parser>) => ()
-  parser.tokens.size := 0;
-  parser.positional-arguments.size := 0;
-  do(reset-option, parser.option-parsers);
-end;
-
-define function add-option
-    (parser :: <command-line-parser>, option :: <option>)
- => ()
-  for (name in option.option-names)
-    if (find-option(parser, name))
-      parser-error("duplicate option name: %=", name);
+define function validate-options (options :: <sequence>)
+  // Don't care if positionals are mixed in with pass-by-names because
+  // positional-options will extract them in order.
+  let names = make(<stretchy-vector>);
+  let repeated-positional = #f;
+  let optional-positional = #f;
+  for (option in options)
+    for (name in option.option-names)
+      if (member?(name, names, test: \=))
+        parser-error("Duplicate option name: %=", name);
+      end;
+      add!(names, name);
     end;
-  end;
-  parser.option-parsers := add!(parser.option-parsers, option);
-end function add-option;
-
-define method find-option
-    (parser :: <command-line-parser>, name :: <string>,
-     #key error? :: <boolean>)
- => (option :: false-or(<option>))
-  let options :: <sequence> = parser.option-parsers;
-  block (return)
-    for (option in parser.option-parsers)
-      for (opt-name in option.option-names)
-        if (opt-name = name)
-          return(option)
-        end;
+    if (repeated-positional)
+      parser-error("only one repeated positional option (currently %=) is"
+                     " allowed and it must be the last option",
+                   repeated-positional.canonical-name);
+    end;
+    if (instance?(option, <positional-option>))
+      if (option.option-repeated?)
+        repeated-positional := option;
+      end;
+      if (option.option-required? & optional-positional)
+        parser-error("required positional option %= may not follow"
+                       " optional positional option %=",
+                     option.canonical-name,
+                     optional-positional.canonical-name);
+      end;
+      if (~option.option-required?)
+        optional-positional := option;
       end;
     end;
-    error? & parser-error("Option not found: %=", name)
-  end block
+  end for;
+end function;
+
+define function positional-options
+    (cmd :: <command>) => (options :: <sequence>)
+  choose(rcurry(instance?, <positional-option>),
+         cmd.command-options)
+end;
+
+define function pass-by-name-options
+    (cmd :: <command>) => (options :: <sequence>)
+  choose(method (o)
+           ~instance?(o, <positional-option>)
+         end,
+         cmd.command-options)
+end function;
+
+define open abstract class <subcommand> (<command>)
+  constant slot subcommand-name :: <string>,
+    required-init-keyword: name:;
+end class;
+
+define method debug-name
+    (subcmd :: <subcommand>) => (name :: <string>)
+  subcmd.subcommand-name
+end method;
+
+// Should this just be another method on execute-command instead?
+define open generic execute-subcommand
+    (parser :: <command-line-parser>, subcmd :: <object>)
+ => (status :: false-or(<integer>));
+
+define method execute-subcommand
+    (parser :: <command-line-parser>, subcmd :: <object>)
+ => (status :: false-or(<integer>))
+  error("don't know how to execute subcommand %=. add an execute-subcommand method?",
+        subcmd);
+end method;
+
+define open class <command-line-parser> (<command>)
+  slot parser-subcommands :: <sequence> = #[],
+    init-keyword: subcommands:;
+  slot selected-subcommand :: false-or(<subcommand>) = #f;
+end class;
+
+// Help options are on by default but may be turned off.
+define method initialize
+    (parser :: <command-line-parser>,
+     #key help-option? :: <boolean> = #t,
+          help-subcommand? :: <boolean> = #t, #all-keys) => ()
+  next-method();
+  if (help-option?)
+    add-help-option(parser);
+  end;
+  if (help-subcommand? & parser.has-subcommands?)
+    add-help-subcommand(parser);
+  end;
+end method;
+
+define function has-subcommands?
+    (parser :: <command-line-parser>) => (_ :: <boolean>)
+  parser.parser-subcommands.size > 0
+end;
+
+define generic find-subcommand
+    (parser :: <command-line-parser>, object)
+ => (subcommand :: false-or(<subcommand>));
+
+define method find-subcommand
+    (parser :: <command-line-parser>, class :: subclass(<subcommand>))
+ => (subcommand :: false-or(<subcommand>))
+  let subs = parser.parser-subcommands;
+  let key = find-key(subs, rcurry(instance?, class));
+  key & subs[key]
+end method;
+
+define method find-subcommand
+    (parser :: <command-line-parser>, name :: <string>)
+ => (subcommand :: false-or(<subcommand>))
+  let subs = parser.parser-subcommands;
+  let key = find-key(subs, method (subcmd)
+                             name = subcmd.subcommand-name
+                           end);
+  key & subs[key]
+end method;
+
+define function add-subcommand
+    (parser :: <command-line-parser>, subcmd :: <subcommand>) => ()
+  let name = subcommand-name(subcmd);
+  if (parser.positional-options.size > 0)
+    parser-error("a command line parser may not have both positional"
+                   " options and subcommands");
+  end;
+  if (find-subcommand(parser, name))
+    parser-error("a subcommand named %= already exists", name);
+  end;
+  parser.parser-subcommands := add!(parser.parser-subcommands, subcmd);
+end function;
+
+define generic execute-command
+    (parser :: <command-line-parser>) => (status :: false-or(<integer>));
+
+define method execute-command
+    (parser :: <command-line-parser>) => (status :: false-or(<integer>))
+  let subcmd = parser.selected-subcommand;
+  if (subcmd)
+    execute-subcommand(parser, subcmd);
+  else
+    format(*standard-error*, "Please specify a subcommand.");
+    let help = find-subcommand(parser, <help-subcommand>);
+    if (help)
+      format(*standard-error*, " Use '%s %s' to see a list of subcommands.",
+             program-name(), help.subcommand-name);
+    end;
+    2                           // usage error
+  end
+end method;
+
+define generic add-option (cmd :: <command>, option :: <option>) => ();
+
+define method add-option
+    (cmd :: <command>, option :: <option>) => ()
+  let new-options = add(cmd.command-options, option);
+  validate-options(new-options);
+  cmd.command-options := new-options;
+end method;
+
+define generic find-option
+    (cmd :: <command>, id :: <object>)
+ => (option :: false-or(<option>));
+
+define method find-option
+    (cmd :: <command>, class :: <class>) => (option :: false-or(<option>))
+  let options = cmd.command-options;
+  let key = find-key(options, rcurry(instance?, class));
+  key & options[key]
+end method;
+
+define method find-option
+    (cmd :: <command>, name :: <string>) => (option :: false-or(<option>))
+  let options = cmd.command-options;
+  let key = find-key(options,
+                     method (option)
+                       member?(name, option.option-names, test: \=)
+                     end);
+  key & options[key]
 end method;
 
 define function get-option-value
-    (parser :: <command-line-parser>, name :: <string>)
- => (value :: <object>)
-  find-option(parser, name).option-value
-end;
+    (parser, name :: <string>) => (value :: <object>)
+  let option = find-option(parser, name);
+  if (option)
+    option.option-value
+  else
+    usage-error("Command line option %= not found.", name);
+  end;
+end function;
 
 define function add-argument-token
-    (parser :: <command-line-parser>,
-     class :: <class>,
-     value :: <string>,
+    (parser :: <command>, class :: <class>, value :: <string>,
      #rest keys, #key, #all-keys)
  => ()
-  push-last(parser.tokens, apply(make, class, value: value, keys));
+  push-last(parser.parser-tokens, apply(make, class, value: value, keys));
 end;
 
-define function argument-tokens-remaining?
-    (parser :: <command-line-parser>)
- => (remaining? :: <boolean>)
-  ~parser.tokens.empty?
+define function tokens-remaining?
+    (parser :: <command>) => (remaining? :: <boolean>)
+  ~parser.parser-tokens.empty?
 end;
 
-define function peek-argument-token
-    (parser :: <command-line-parser>)
- => (token :: false-or(<token>))
-  unless (argument-tokens-remaining?(parser))
+define function peek-token
+    (parser :: <command>) => (token :: false-or(<token>))
+  unless (tokens-remaining?(parser))
     usage-error("Ran out of arguments.")
   end;
-  parser.tokens[0];
+  parser.parser-tokens[0];
 end;
 
-define function get-argument-token
-    (parser :: <command-line-parser>)
- => (token :: false-or(<token>))
-  unless (argument-tokens-remaining?(parser))
+define function pop-token
+    (parser :: <command>) => (token :: false-or(<token>))
+  unless (tokens-remaining?(parser))
     usage-error("Ran out of arguments.")
   end;
-  pop(parser.tokens);
+  pop(parser.parser-tokens);
 end;
 
 
@@ -212,23 +348,37 @@ end;
 //  <option>
 //======================================================================
 
-define abstract open primary class <option> (<object>)
-  // Information supplied by creator. Note that the first element is used
-  // by canonical-option-name to generate a usage message.
-  slot option-names :: <sequence> = #(),
+define abstract open class <option> (<object>)
+  slot option-names :: <sequence>,
     required-init-keyword: names:;
+
   constant slot option-type :: <type> = <object>,
     init-keyword: type:;
+
   slot option-might-have-parameters? :: <boolean> = #t;
-  slot option-value-is-collection? :: <boolean> = #f;
-  constant slot %option-help :: <string> = "",
-    init-keyword: help:;
+
+  // Whether or not the option may be specified multiple times.  If the option
+  // is also `option-required?` then it must be specified at least once.
+  slot option-repeated? :: <boolean> = #f,
+    init-keyword: repeated?:;
+
+  // If true, the option must be specified at least once on the command-line.
+  // TODO(cgay): This should be valid for both pass-by-name and positional
+  // options but is currently not enforced for named options.
+  constant slot option-required? :: <boolean> = #f,
+    init-keyword: required?:;
+
+  // Text to display for the --help option or `help` subcommand.
+  constant slot %option-help :: <string>,
+    required-init-keyword: help:;
+
   // This shows up in the generated synopsis after the option name.
   // e.g., "HOST" in  "--hostname  HOST  A host name."  If not supplied
   // it defaults to the first long option name.
   constant slot %option-variable :: false-or(<string>) = #f,
     init-keyword: variable:;
-  // TODO(cgay): This should be a unique-id instead.
+
+  // TODO(cgay): This should be a unique-id instead of #f.
   constant slot option-default :: <object> = #f,
     init-keyword: default:;
 
@@ -237,139 +387,66 @@ define abstract open primary class <option> (<object>)
   slot option-value :: <object> = #f;
 end class <option>;
 
+define method make
+    (class :: subclass(<option>), #rest args, #key name, names) => (o :: <option>)
+  // Allow `name: "foo"` (the common case, I hope) or `names: #("foo", "f")`.
+  // Is this featuritis? I hate having to say `names: #("foo")` when there's
+  // only one name.
+  let names = if (instance?(names, <string>))
+                list(names)
+              else
+                names | #()
+              end;
+  if (name)
+    names := concatenate(list(name), names);
+  end;
+  apply(next-method, class, names: names, args)
+end method;
+
 define method initialize
     (option :: <option>, #key) => ()
   next-method();
+  if (empty?(option.option-names))
+    parser-error("At least one option name is required: %=", option);
+  end;
   let default = option.option-default;
   let type = option.option-type;
   if (default)
-    if (option.option-value-is-collection?)
+    if (option.option-repeated?)
       type := <collection>
     end;
     if (~instance?(default, type))
-      parser-error("The default value (%=) for option %s is not of the correct "
+      parser-error("The default value (%=) for option %= is not of the correct "
                      "type (%s).", default, option.option-names, type);
     end;
+    option.option-value := default;
   end;
 end method initialize;
 
-// Reset the option-value back to the option-default.
-define open generic reset-option
-    (option :: <option>) => ();
+define method debug-name
+    (option :: <option>) => (name :: <string>)
+  join(option.option-names, ", ")
+end method;
 
-// TODO(cgay): Make <boolean>s print as true/false in %default
-// substitutions.  There's some subtlety for <flag-option> because of
-// negative options.
-// TODO(cgay): "%choices"
-define variable *percent-substitutions*
-  = list(list("%%", method (_) "%" end),  // must come first
-         list("%default", method (option)
-                            format-to-string("%s", option.option-default)
-                          end),
-         list("%app", method (_)
-                        locator-base(as(<file-locator>, application-name()))
-                      end));
 
-// For use by extension modules.
-define function add-percent-substitution
-    (token :: <string>, fn :: <function>) => ()
-  *percent-substitutions*
-    := concatenate(*percent-substitutions*, list(list(token, fn)));
-end;
+// ----------------------
+// parse-option-value
+// ----------------------
 
-// Return a help string (description) for an option with substitutions
-// performed for %default, %app, etc.
-define method option-help
-    (option :: <option>) => (help :: <string>)
-  // TODO(cgay): If %prefix and %prefixplusmore exist, the result
-  // depends on the order of items in *percent-substitutions*, which
-  // is bad.
-  let text = option.%option-help;
-  iterate loop (i = 0)
-    if (i >= text.size)
-      text
-    elseif (text[i] = '%')
-      let epos = i + 1;
-      let done = #f;
-      for (item in *percent-substitutions*,
-           until: done)
-        let (token, fn) = apply(values, item);
-        if (string-equal?(text, token, start1: i, end1: min(i + token.size, text.size)))
-          let subst = fn(option);
-          text := replace-substrings(text, token, subst, start: i, end: i + token.size);
-          epos := epos + subst.size - 1;
-          done := #t;
-        end;
-      end;
-      loop(epos)
-    else
-      loop(i + 1)
-    end
-  end
-end method option-help;
-
-define method option-variable
-    (option :: <option>) => (variable-name :: <string>)
-  option.%option-variable
-    | uppercase(canonical-option-name(option, plain?: #t))
-end;
-
-// Parse a parameter value passed on the command line (a string)
-// to the type specified by option-type.
-define open generic parse-option-parameter
+// Parse a value passed on the command line (a string) to the type specified by
+// option-type.
+define open generic parse-option-value
     (parameter :: <string>, type :: <type>) => (value :: <object>);
 
-// Read tokens from the command line and decide how to store them.
-define open generic parse-option
-    (option :: <option>, args :: <command-line-parser>) => ();
-
-
-define method reset-option
-    (option :: <option>) => ()
-  option.option-present? := #f;
-  option.option-value := option.option-default;
-end method reset-option;
-
-define method visible-option-name
-    (raw-name :: <string>) => (dash-name :: <string>)
-  concatenate(if (raw-name.size = 1) "-" else "--" end, raw-name)
-end;
-
-define method canonical-option-name
-    (option :: <option>, #key plain?) => (dash-name :: <string>)
-  if (plain?)
-    option.option-names.first
-  else
-    option.option-names.first.visible-option-name
-  end
-end;
-
-
-// Return a string showing how this option is used on the command-line.
-// For use in the 'Usage:' line of --help output.
-define open generic format-option-usage
-    (option :: <option>) => (usage :: <string>);
-
-define method format-option-usage
-    (option :: <option>) => (usage :: <string>)
-  option.canonical-option-name
-end;
-
-
-
-// ----------------------
-// parse-option-parameter
-// ----------------------
-
-// Default method just returns parameter.
-define method parse-option-parameter
+// Default method just returns the value.
+define method parse-option-value
     (param :: <string>, type :: <type>) => (value :: <string>)
   param
 end;
 
 // This is essentially for "float or int", which could be <real>, but
 // <number> is also a natural choice.
-define method parse-option-parameter
+define method parse-option-value
     (param :: <string>, type :: subclass(<number>)) => (value :: <number>)
   let arg = lowercase(param);
   /*  no string-to-float yet
@@ -387,7 +464,7 @@ define method parse-option-parameter
   end
 end;
 
-define method parse-option-parameter
+define method parse-option-value
     (param :: <string>, type == <boolean>) => (value :: <boolean>)
   if (member?(param, #("yes", "true", "on"), test: string-equal-ic?))
     #t
@@ -398,29 +475,40 @@ define method parse-option-parameter
   end
 end;
 
-define method parse-option-parameter
+define method parse-option-value
     (param :: <string>, type == <symbol>) => (value :: <symbol>)
   as(<symbol>, param)
 end;
 
-define method parse-option-parameter
+define method parse-option-value
     (param :: <string>, type :: subclass(<sequence>)) => (value :: <sequence>)
   as(type, map(strip, split(param, ",")))
 end;
 
 // override subclass(<sequence>) method
-define method parse-option-parameter
-    (param :: <string>, type == <string>) => (value :: <string>)
+define method parse-option-value
+    (param :: <string>, type :: subclass(<string>)) => (value :: <string>)
   param
 end;
 
 
-define method short-names
-    (option :: <option>) => (names :: <list>)
+define generic short-names (option :: <option>) => (names :: <list>);
+
+define method short-names (option :: <positional-option>) => (names :: <list>)
+  #()
+end;
+
+define method short-names (option :: <option>) => (names :: <list>)
   choose(method (name :: <string>)
            name.size = 1
          end,
          option.option-names)
+end;
+
+define generic long-names (option :: <option>) => (names :: <list>);
+
+define method long-names (option :: <positional-option>) => (names :: <list>)
+  #()
 end;
 
 define method long-names
@@ -441,7 +529,12 @@ define abstract class <token> (<object>)
     required-init-keyword: value:;
 end;
 
-define class <positional-option-token> (<token>)
+define method debug-name
+    (token :: <token>) => (name :: <string>)
+  token.token-value
+end method;
+
+define class <argument-token> (<token>)
 end;
 
 define abstract class <option-token> (<token>)
@@ -515,30 +608,47 @@ end function chop-args;
 define function tokenize-args
     (parser :: <command-line-parser>, args :: <deque> /* of: <string> */)
  => ()
+  local
+    // Attempt to get the next argument a little bit early.
+    method next-arg () => (arg :: <string>)
+      if (empty?(args))
+        usage-error("Ran out of arguments.");
+      else
+        pop(args)
+      end
+    end,
+    // Add a token to our deque
+    method token (class :: <class>, value :: <string>,
+                  #rest keys, #key, #all-keys) => ()
+      apply(add-argument-token, parser, class, value, keys);
+    end,
+    method parse-short-option (arg)
+      block (done)
+        for (i from 1 below arg.size)
+          let name = copy-sequence(arg, start: i, end: i + 1);
+          let opt = find-option(parser, name);
+          if (opt
+                & opt.option-might-have-parameters?
+                & i + 1 < arg.size)
+            // Take rest of argument, and use it as a parameter.
+            token(<short-option-token>, name, tightly-bound?: #t);
+            token(<argument-token>,
+                  copy-sequence(arg, start: i + 1));
+            done();
+          else
+            // A solitary option with no parameter.
+            // TODO(cgay): why do we not exit the loop here??
+            token(<short-option-token>, name);
+          end if;
+        end for;
+      end block;
+    end method;
   until (args.empty?)
     let arg = pop(args);
-    local
-
-      // Attempt to get the next argument a little bit early.
-      method next-arg() => (arg :: <string>)
-        if (~args.empty?)
-          pop(args)
-        else
-          usage-error("Ran out of arguments.");
-        end
-      end method,
-
-      // Add a token to our deque
-      method token(class :: <class>, value :: <string>,
-                   #rest keys, #key, #all-keys) => ()
-        apply(add-argument-token, parser, class, value, keys);
-      end method;
-
-    // Process an individual argument
     case
       (arg = "=") =>
         token(<equals-token>, "=");
-        token(<positional-option-token>, next-arg());
+        token(<argument-token>, next-arg());
 
       starts-with?(arg, "--") =>
         token(<long-option-token>, copy-sequence(arg, start: 2));
@@ -546,222 +656,123 @@ define function tokenize-args
       starts-with?(arg, "-") =>
         if (arg.size = 1)
           // Probably a fake filename representing stdin ('cat -')
-          token(<positional-option-token>, "-");
+          token(<argument-token>, "-");
         else
-          block (done)
-            for (i from 1 below arg.size)
-              let opt = make(<string>, size: 1, fill: arg[i]);
-              let opt-parser = find-option(parser, opt);
-              if (opt-parser & opt-parser.option-might-have-parameters?
-                    & i + 1 < arg.size)
-                // Take rest of argument, and use it as a parameter.
-                token(<short-option-token>, opt, tightly-bound?: #t);
-                token(<positional-option-token>,
-                      copy-sequence(arg, start: i + 1));
-                done();
-              else
-                // A solitary option with no parameter.
-                token(<short-option-token>, opt);
-              end if;
-            end for;
-          end block;
+          parse-short-option(arg);
         end if;
 
       otherwise =>
-        token(<positional-option-token>, arg);
+        token(<argument-token>, arg);
     end case;
   end until;
 end function tokenize-args;
 
 define open generic parse-command-line
-    (parser :: <command-line-parser>, argv :: <sequence>,
-     #key usage, description)
+    (parser :: <command-line-parser>, argv :: <sequence>)
  => ();
 
+// Parse the command line, side-effecting the parser, its options, and its
+// subcommands with the parsed values. `args` is a sequence of command line
+// arguments (strings). It must not include the command name.
 define method parse-command-line
-    (parser :: <command-line-parser>, argv :: <sequence>,
-     #key usage :: false-or(<string>),
-          description :: false-or(<string>))
- => ()
-  reset-parser(parser);
-  let do-help? = parser.provide-help-option?;
-  if (do-help? & ~any?(curry(find-option, parser),
-                       parser.help-option.option-names))
-    add-option(parser, parser.help-option);
-  end;
-  block ()
-    %parse-command-line(parser, argv, usage, description);
-  exception (ex :: <usage-error>)
-    if (do-help? & ~instance?(ex, <help-requested>))
-      format(*standard-error*,
-             "Error: %s\nUse %s to see command-line options.\n",
-             ex,
-             join(map(visible-option-name, parser.help-option.option-names), ", ",
-                  conjunction: " or "));
-      // Rather than calling exit-application here we raise a subclass
-      // of <usage-error>.  If/when exit-application raises an
-      // exception rather than calling exit() we can call it here
-      // instead.  That simplifies the calling code (since it doesn't
-      // HAVE to handle errors), allows the caller to handle it if it
-      // wants, and makes THIS code testable.
-    end;
-    signal(ex)
-  end;
-end method parse-command-line;
-
-define function %parse-command-line
-    (parser :: <command-line-parser>, argv :: <sequence>,
-     usage :: false-or(<string>), description :: false-or(<string>))
+    (parser :: <command-line-parser>, args :: <sequence>)
  => ()
   // Split our args around '--' and chop them around '='.
-  let (clean-args, extra-args) = split-args(argv);
+  let (clean-args, extra-args) = split-args(args);
   let chopped-args = chop-args(clean-args);
-
-  // Tokenize our arguments and suck them into the parser.
   tokenize-args(parser, chopped-args);
+  process-tokens(parser, #f);
 
-  // Process our tokens.
-  while (argument-tokens-remaining?(parser))
-    let token = peek-argument-token(parser);
+  if (~empty?(extra-args))
+    // Append any more positional options from after the '--'.  If there's a
+    // subcommand the extra args go with that.
+    // (This feels hackish. Can we handle this directly in process-tokens?)
+    let command = parser.selected-subcommand | parser;
+    let option = last(command.command-options);
+    if (~(instance?(option, <positional-option>)
+            & option.option-repeated?))
+      let opts = command.positional-options;
+      usage-error("Only %d positional argument%s allowed.",
+                  opts.size,
+                  if (opts.size = 1) "" else "s" end);
+    end;
+    for (arg in extra-args)
+      option.option-value := add!(option.option-value,
+                                  parse-option-value(arg, option.option-type));
+    end for;
+  end;
+end method;
+
+// Read tokens from the command line and decide how to store them.
+// Implement this for each new option class.
+define open generic parse-option
+    (option :: <option>, args :: <command>) => ();
+
+// Process the tokens, side-effecting the <command>, the <subcommand> (if any),
+// and the <option>s. If a subcommand is encountered, the remaining tokens are
+// passed to it and this is called recursively.
+//
+// One bit of subtlety here (which would be cleaned up by separating the parser
+// from the command descriptions) is that the full tokenized command line is
+// stored in the <command-line-parser> while some of the options may be stored
+// in a <subcommand>.
+define function process-tokens
+    (parser :: <command-line-parser>, subcmd :: false-or(<subcommand>))
+  let pos-opts = as(<list>, (subcmd | parser).positional-options);
+  while (tokens-remaining?(parser))
+    let token = peek-token(parser);
     let value = token.token-value;
     select (token by instance?)
-      <positional-option-token> =>
-        get-argument-token(parser);
-        parser.positional-arguments := add!(parser.positional-arguments, value);
+      <argument-token> =>
+        // Got an argument token without a preceding <short/long-option-token>
+        // so it must be a subcommand or a positional argument.
+        if (~subcmd & parser.has-subcommands?)
+          let sub = find-subcommand(parser, value)
+            | usage-error("%= does not name a subcommand.", value);
+          pop-token(parser);
+          parser.selected-subcommand := sub;
+          //subcommand.parser-tokens := parser.parser-tokens;
+          process-tokens(parser, sub);
+        else
+          if (empty?(pos-opts))
+            usage-error("Too many positional arguments: %=", value);
+          end;
+          let option = head(pos-opts);
+          if (option.option-repeated?)
+            assert(pos-opts.size = 1);
+          else
+            pos-opts := tail(pos-opts);
+          end;
+          parse-option(option, parser);
+          option.option-present? := #t;
+        end;
       <short-option-token>, <long-option-token> =>
         let option = find-option(parser, value)
           | usage-error("Unrecognized option: %s%s",
                         if (value.size = 1) "-" else "--" end,
                         value);
+        if (instance?(option, <help-option>))
+          // Handle --help early in case the remainder of the command line is
+          // invalid or there are missing required arguments.
+          print-synopsis(parser, subcmd);
+          abort-command(0);
+        end;
         parse-option(option, parser);
         option.option-present? := #t;
       otherwise =>
-        parser-error("Unexpected token: %=", value);
+        usage-error("Unexpected token: %=", value);
     end select;
   end while;
-
-  // Handle help prior to validating positional options.
-  if (parser.provide-help-option? & parser.help-option.option-value)
-    print-synopsis(parser, *standard-output*,
-                   usage: usage, description: description);
-    error(make(<help-requested>));
+  let missing = choose(method (o)
+                         o.option-required? & ~o.option-present?
+                       end,
+                       pos-opts);
+  if (missing.size > 0)
+    usage-error("Missing argument%s: %s",
+                if (missing.size = 1) "" else "s" end,
+                join(missing, ", ", key: canonical-name));
   end;
-
-  // And append any more positional options from after the '--'.
-  for (arg in extra-args)
-    parser.positional-arguments := add!(parser.positional-arguments, arg);
-  end for;
-  let nargs = parser.positional-arguments.size;
-  let min-args = parser.min-positional-arguments;
-  let max-args = parser.max-positional-arguments;
-  if (min-args = max-args & nargs ~= min-args)
-    usage-error("Exactly %d positional option%s required.",
-                min-args,
-                if (nargs = 1) "" else "s are" end);
-  end;
-  if (nargs < min-args)
-    usage-error("Not enough positional options supplied.");
-  end;
-  if (nargs > max-args)
-    usage-error("Too many positional options supplied.");
-  end;
-end function %parse-command-line;
-
-define open generic print-synopsis
-    (parser :: <command-line-parser>, stream :: <stream>,
-     #key usage, description)
- => ();
-
-// TODO(cgay): Show all option names, not just the first.
-// TODO(cgay): Annotate the repeatable options with "..."
-// TODO(cgay): Wrap the descriptions nicely
-//
-// Example output:
-// Usage: foo [options] arg1 ...
-//   -c, --coolness LEVEL      Level of coolness, 1-3.
-//   -r RECURSIVE              Be cool recursively.
-//       --alacrity ALACRITY   Level of alacrity.
-// Short options come first on a line because they're always the
-// same length (except when there are many).  Long options start
-// indented past one short option if there is no corresponding
-// short option.  If there is no variable: provided for the option
-// it defaults to the first long option name.
-define method print-synopsis
-    (parser :: <command-line-parser>, stream :: <stream>,
-     #key usage :: false-or(<string>),
-          description :: false-or(<string>))
- => ()
-  format(stream, "%s\n", usage | generate-usage(parser));
-  description & format(stream, "%s\n", description);
-
-  // These contain an entry for every line, sometimes just "".
-  let (names, docs) = synopsis-columns(parser);
-  let name-width = reduce1(max, map(size, names));
-  for (name in names, doc in docs)
-    format(stream, "%s  %s\n", pad-right(name, name-width), doc);
-  end;
-end method print-synopsis;
-
-define function synopsis-columns
-    (parser :: <command-line-parser>)
- => (names :: <sequence>, docs :: <sequence>)
-  let names = make(<stretchy-vector>);
-  let docs = make(<stretchy-vector>);
-  let any-shorts? = any?(method (opt) ~empty?(opt.short-names) end,
-                         parser.option-parsers);
-  for (option in parser.option-parsers)
-    // TODO(cgay): Make these prefixes (-- and -) configurable.
-    let longs = map(curry(concatenate, "--"), option.long-names);
-    let shorts = map(curry(concatenate, "-"), option.short-names);
-    let name = concatenate(join(concatenate(shorts, longs), ", "),
-                           " ",
-                           case
-                             instance?(option, <flag-option>) => "";
-                             empty?(longs) => "X";
-                             otherwise =>
-                               option.option-variable
-                                 | uppercase(option.long-names[0])
-                           end);
-    let indent = if (empty?(shorts) & any-shorts?)
-                   // Makes long options align (usually).
-                   "      "
-                 else
-                   "  "
-                 end;
-    add!(names, concatenate(indent, name));
-    // TODO(cgay): Wrap doc text.
-    add!(docs, option.option-help);
-  end for;
-  values(names, docs)
-end function synopsis-columns;
-
-// Generate a default usage message based on the given parser.
-// TODO(cgay): This can be improved once the parser knows more about
-//   how many positional arguments are allowed.
-define method generate-usage
-    (parser :: <command-line-parser>) => (usage :: <string>)
-  let optionals? = #f;
-  let requireds = make(<stretchy-vector>);
-  for (option in parser.option-parsers)
-    if (#f /* TODO(cgay): option.required? */)
-      add!(requireds, option)
-    else
-      optionals? := #t;
-    end;
-  end;
-  with-output-to-string (usage)
-    let app = locator-base(as(<file-locator>, application-name()));
-    format(usage, "Usage: %s", app);
-    optionals? & format(usage, " [options]");
-    if (~empty?(requireds))
-      format(usage, " %s", join(map(format-option-usage, requireds), " "));
-    end;
-    // TODO(cgay): positional1 positional2 ...
-    format(usage, "\n");
-  end
-end method generate-usage;
-
-
+end function;
 /*
   Semi-comprehensible design notes, here for historical interest:
 

--- a/command-line-parser.dylan
+++ b/command-line-parser.dylan
@@ -117,9 +117,6 @@ define open class <command-line-parser> (<object>)
     make(<string-table>);
   constant slot option-long-name-map :: <string-table> /* of <option> */ =
     make(<string-table>);
-  // name => might-have-parameters?
-  constant slot parameter-options :: <string-table> /* of <boolean> */ =
-    make(<string-table>);
 
   constant slot tokens :: <deque> /* of: <token> */ =
     make(<deque> /* of: <token> */);
@@ -169,11 +166,6 @@ define function add-option
   add-to-table(parser.option-short-name-map,
                option.short-names,
                option);
-  if (option.option-might-have-parameters?)
-    add-to-table(parser.parameter-options,
-                 option.short-names,
-                 #t);
-  end if;
   parser.option-parsers := add!(parser.option-parsers, option);
 end function add-option;
 

--- a/command-line-parser.lid
+++ b/command-line-parser.lid
@@ -3,4 +3,5 @@ target-type:  dll
 files:        library
               command-line-parser
               parsers
+              help
               macros

--- a/help.dylan
+++ b/help.dylan
@@ -1,0 +1,316 @@
+Module: command-line-parser
+Synopsis: Implements the --help flag and help subcommand
+
+
+// TODO(cgay): Wrap the descriptions nicely
+
+define function program-name () => (name :: <string>)
+  locator-base(as(<file-locator>, application-name()))
+end function;
+
+define method command-help
+    (cmd :: <command>) => (help :: <string>)
+  let result = cmd.%command-help;
+  for (subst in *pattern-substitutions*)
+    let replacement = subst.substitution-function(result);
+    if (replacement)
+      result := replace-substrings(result, subst.substitution-pattern, replacement);
+    end;
+  end;
+  result
+end method;
+
+// make open generic?
+define function add-help-subcommand
+    (parser :: <command-line-parser>) => ()
+  add-subcommand(parser,
+                 make(<help-subcommand>,
+                      name: "help",
+                      help: "Display help for a subcommand.",
+                      options: list(make(<positional-option>,
+                                         name: "subcommand",
+                                         required?: #f,
+                                         help: "A subcommand name."))))
+end function;
+
+// TODO(cgay): we also have canonical-option-name, but I don't like it; it's
+// overkill. Need to have a look at format-option-usage...
+define function canonical-name
+    (option :: <option>) => (name :: <string>)
+  option.option-names[0]
+end function;
+
+define method option-help
+    (option :: <option>) => (help :: <string>)
+  let result = option.%option-help;
+  for (subst in *pattern-substitutions*)
+    let replacement = subst.substitution-function(option);
+    result := replace-substrings(result, subst.substitution-pattern, replacement);
+  end;
+  result
+end method;
+
+define method option-variable
+    (option :: <option>) => (variable-name :: <string>)
+  option.%option-variable
+    | uppercase(canonical-name(option))
+end;
+
+define class <help-subcommand> (<subcommand>)
+  keyword name = "help";
+  keyword help = "Display help message for a subcommand.";
+end class;
+
+define method execute-subcommand
+    (parser :: <command-line-parser>, subcmd :: <help-subcommand>)
+ => (status :: false-or(<integer>));
+  let name = get-option-value(subcmd, "subcommand");
+  if (name)
+    let subcmd = find-subcommand(parser, name);
+    if (subcmd)
+      print-synopsis(parser, subcmd);
+    else
+      usage-error("Subcommand %= not found.", name);
+    end;
+  else
+    print-synopsis(parser, #f);     // 'app help' same as 'app --help'
+  end;
+end method;
+
+// This has a class of its own so that the help option doesn't have to be
+// identified by name (which should be user settable).
+define open class <help-option> (<flag-option>)
+end;
+
+// make open generic?
+define function add-help-option
+    (parser :: <command-line-parser>) => ()
+  add-option(parser, make(<help-option>,
+                          names: #("help", "h"),
+                          help: "Display this message."));
+end function;
+
+define class <substitution> (<object>)
+  constant slot substitution-pattern :: <string>, required-init-keyword: pattern:;
+  constant slot substitution-function :: <function>, required-init-keyword: function:;
+end class;
+
+// TODO(cgay): "%choices%"
+define variable *pattern-substitutions*
+  = list(make(<substitution>,
+              pattern: "%default%",
+              function: method (option)
+                          if (instance?(option, <option>))
+                            // TODO(cgay): Make <boolean>s print as true/false in
+                            // %default% substitutions.  There's some subtlety for
+                            // <flag-option> because of negative options.
+                            // Make a format-option-value generic?
+                            format-to-string("%s", option.option-default)
+                          end
+                        end),
+         make(<substitution>,
+              pattern: "%app%",
+              function: always(program-name())));
+
+// For use by extension modules.
+define function add-pattern-substitution
+    (pattern :: <string>, fn :: <function>) => ()
+  *pattern-substitutions*
+    := concatenate(*pattern-substitutions*,
+                   make(<substitution>, pattern: pattern, function: fn));
+end function;
+
+define method visible-option-name
+    (raw-name :: <string>) => (dash-name :: <string>)
+  concatenate(if (raw-name.size = 1) "-" else "--" end, raw-name)
+end;
+
+define method canonical-option-name
+    (option :: <option>, #key plain?) => (dash-name :: <string>)
+  if (plain?)
+    option.option-names.first
+  else
+    option.option-names.first.visible-option-name
+  end
+end;
+
+// Return a string showing how this option is used on the command-line.
+// TODO(cgay): this is not called. I probably broke it at some point.
+// I think it should affect the way the option is displayed in the Options:
+// table. e.g., "--flag[=yes/no]"
+define open generic format-option-usage
+    (option :: <option>) => (usage :: <string>);
+
+define method format-option-usage
+    (option :: <option>) => (usage :: <string>)
+  option.canonical-option-name
+end;
+
+define open generic print-synopsis
+    (parser :: <command-line-parser>, subcmd :: false-or(<subcommand>), #key stream);
+
+define method print-synopsis
+    (parser :: <command-line-parser>, subcmd == #f,
+     #key stream :: <stream> = *standard-output*)
+  format(stream, "%s\n", parser.command-help);
+  format(stream, "\n%s\n", generate-usage(parser));
+  print-options(stream, parser,
+                if (empty?(parser-subcommands(parser)))
+                  "Options:"
+                else
+                  "Global options:"
+                end);
+  if (~empty?(parser-subcommands(parser)))
+    format(stream, "\nSubcommands:\n");
+    let (names, docs) = subcommand-columns(parser);
+    if (~empty?(names))
+      let name-width = reduce1(max, map(size, names));
+      for (name in names, doc in docs)
+        format(stream, "%s  %s\n", pad-right(name, name-width), doc);
+      end;
+    end;
+    let help-subcommand = find-subcommand(parser, <help-subcommand>);
+    if (help-subcommand)
+      format(stream, "\nUse '%s %s <subcommand>' to see subcommand options.\n",
+             program-name(), subcommand-name(help-subcommand));
+    end;
+  end;
+end method;
+
+define method print-synopsis
+    (parser :: <command-line-parser>, subcmd :: <subcommand>,
+     #key stream :: <stream> = *standard-output*)
+  format(stream, "%s\n", subcmd.command-help);
+  format(stream, "\n%s\n", generate-usage(subcmd));
+  print-options(stream, subcmd, "Options:");
+  let help-option = find-option(parser, <help-option>);
+  if (help-option)
+    format(stream, "\nUse '%s %s' to see global options.\n",
+           program-name(), help-option.canonical-name.visible-option-name);
+  end;
+end method;
+
+define method print-options
+    (stream :: <stream>, command :: <command>, header :: <string>) => ()
+  let (names, docs) = option-columns(command);
+  if (~empty?(names))
+    format(stream, "\n%s\n", header);
+    let name-width = reduce1(max, map(size, names));
+    for (name in names, doc in docs)
+      format(stream, "  %s  %s\n", pad-right(name, name-width), doc);
+    end;
+  end;
+  let (names, docs) = positional-columns(command);
+  if (~empty?(names))
+    format(stream, "\nPositional arguments:\n");
+    let name-width = reduce1(max, map(size, names));
+    for (name in names, doc in docs)
+      format(stream, "  %s  %s\n", pad-right(name, name-width), doc);
+    end;
+  end;
+end method;
+
+define function positional-columns
+    (cmd :: <command>) => (names :: <sequence>, docs :: <sequence>)
+  let names = make(<stretchy-vector>);
+  let docs = make(<stretchy-vector>);
+  for (opt in cmd.positional-options)
+    let name = opt.option-variable;
+    if (opt.option-repeated?)
+      name := concatenate(name, "...");
+    end;
+    add!(names, name);
+    add!(docs, opt.option-help);
+  end;
+  values(names, docs)
+end function;
+
+define function option-columns
+    (parser :: <command>)
+ => (names :: <sequence>, docs :: <sequence>)
+  let names = make(<stretchy-vector>);
+  let docs = make(<stretchy-vector>);
+  let any-shorts? = any?(method (opt) ~empty?(opt.short-names) end,
+                         parser.command-options);
+  for (option in parser.pass-by-name-options)
+    let longs = map(visible-option-name, option.long-names);
+    let shorts = map(visible-option-name, option.short-names);
+    let name = concatenate(join(concatenate(shorts, longs), ", "),
+                           " ",
+                           if (instance?(option, <flag-option>))
+                             ""
+                           else
+                             option.option-variable | canonical-name(option);
+                           end);
+    let indent = if (empty?(shorts) & any-shorts?)
+                   "    "       // Makes long options align (usually).
+                 else
+                   ""
+                 end;
+    add!(names, concatenate(indent, name));
+    add!(docs, option.option-help);
+  end for;
+  values(names, docs)
+end function;
+
+// There is much work to be done to make this better.
+define function subcommand-columns
+    (parser :: <command-line-parser>)
+ => (names :: <sequence>, docs :: <sequence>)
+  let names = make(<stretchy-vector>);
+  let docs = make(<stretchy-vector>);
+  for (subcmd in parser.parser-subcommands)
+    add!(names, concatenate("  ", subcmd.subcommand-name));
+    // TODO(cgay): Wrap doc text.
+    add!(docs, subcmd.command-help);
+  end for;
+  values(names, docs)
+end function;
+
+// Generate a one-line usage message showing the order of options and arguments.
+define generic generate-usage
+    (cmd :: <command>) => (usage :: <string>);
+
+define method generate-usage
+    (cmd :: <command-line-parser>) => (usage :: <string>)
+  with-output-to-string (stream)
+    // Be careful to show where the two sets of options (global/sub) must go.
+    let subs? = cmd.has-subcommands?;
+    format(stream, "Usage: %s", program-name());
+    if (cmd.pass-by-name-options.size > 0)
+      format(stream, " [%soptions]", if (subs?) "global " else "" end);
+    end;
+    if (subs?)
+      format(stream, " <subcommand> [sub options] args...")
+    end;
+    print-positional-args(stream, cmd);
+  end
+end method;
+
+define method generate-usage
+    (subcmd :: <subcommand>) => (usage :: <string>)
+  with-output-to-string (stream)
+    format(stream, "Usage: %s %s%s", program-name(), subcommand-name(subcmd),
+           if (subcmd.pass-by-name-options.size > 0)
+             " [options]"
+           else
+             ""
+           end);
+    print-positional-args(stream, subcmd);
+  end;
+end method;
+
+define function print-positional-args
+    (stream :: <stream>, cmd :: <command>) => ()
+  // When positional options are added to the command we verify that certain
+  // constraints are met, like you can't add a repeated arg before a
+  // non-repeated arg or add an optional arg before a required arg, so here we
+  // assume those properties hold.
+  for (option in cmd.positional-options)
+    let var = option.option-variable;
+    format(stream,
+           if (option.option-required?) " %s%s" else " [%s]%s" end,
+           var,
+           if (option.option-repeated?) " ..." else "" end);
+  end;
+end function;

--- a/library.dylan
+++ b/library.dylan
@@ -4,6 +4,8 @@ copyright: See LICENSE file in this distribution.
 
 define library command-line-parser
   use common-dylan;
+  use dylan,
+    import: { dylan-extensions };
   use io;
   use strings;
   use system;
@@ -17,12 +19,13 @@ end library;
 define module option-parser-protocol
   create
     // <command-line-parser>
-      reset-parser,
-      argument-tokens-remaining?,
-      get-argument-token,
-      peek-argument-token,
+      tokens-remaining?,
+      pop-token,
+      peek-token,
       find-option,
-      add-percent-substitution,
+      add-pattern-substitution,
+      selected-subcommand,
+      positional-options,
 
     // <option>
       option-present?,
@@ -30,17 +33,16 @@ define module option-parser-protocol
       option-help,
       option-default,
       option-might-have-parameters?, option-might-have-parameters?-setter,
-      option-value-is-collection?, option-value-is-collection?-setter,
+      option-repeated?, option-repeated?-setter,
       option-value, option-value-setter,
       option-variable,
-    reset-option,
     parse-option,
     negative-option?,
     format-option-usage,
 
     <token>,
       token-value,
-    <positional-option-token>,
+    <argument-token>,
     <option-token>,
     <short-option-token>,
       tightly-bound-to-next-token?, // XXX - not implemented fully
@@ -50,7 +52,10 @@ end module option-parser-protocol;
 
 // Used by most programs.
 define module command-line-parser
-  use common-dylan, exclude: { format-to-string };
+  use common-dylan,
+    exclude: { format-to-string };
+  use dylan-extensions,
+    import: { debug-name };
   use format;
   use locators;
   use option-parser-protocol;
@@ -60,36 +65,52 @@ define module command-line-parser
 
   export
     <command-line-parser>,
-    positional-options,         // deprecated. not options.
-    positional-arguments,
+    execute-command,
     add-option,
     parse-command-line,
     get-option-value,
     print-synopsis,
 
-    // This is exported from the main module because it is expected to
-    // be used relatively frequently for user types.
-    parse-option-parameter,
+    parse-option-value;
 
+  // Subcommands
+  export
+    <subcommand>,               // Subclass this for each subcommand...
+    <help-subcommand>,          // ...except use this for the help subcommand.
+    execute-subcommand;         // Override this for each subcommand.
+
+  // Option classes
+  export
     <option>,
-    <flag-option>,
-    <parameter-option>,
-    <repeated-parameter-option>,
-    <optional-parameter-option>,
-    <choice-option>,
-    <keyed-option>,
+    <flag-option>,               // --opt or --opt=yes/no
+    <help-option>,               // --help (handled specially)
+    <parameter-option>,          // --opt=value
+    <choice-option>,             // --opt=<one of a, b, or c>
+    <repeated-parameter-option>, // --opt=a --opt=b
+    <optional-parameter-option>, // --opt (gives #t) or --opt=x
+    <keyed-option>,              // --opt k1=v1 --opt k2=v2
+    <positional-option>;         // Args with no - or -- preceding.
+                                 // Must follow all - or -- options.
 
+  // Error handling
+  export
     <command-line-parser-error>,
-      <usage-error>,
-        <help-requested>,
-    usage-error;
+      <abort-command-error>,    // Always catch this in main function.
+        <usage-error>,          // Optionally handle this also.
+    abort-command,              // Terminate the command with an exit status.
+    exit-status,                // Status code from <abort-command-error>.
+    usage-error;                // Terminate the command with a message.
 
+  // define command-line
   export
     command-line-definer,
     defcmdline-rec,
     defcmdline-aux,
     defcmdline-class,
     defcmdline-init,
-    defcmdline-accessors,
-    defcmdline-synopsis;
+    defcmdline-accessors;
+
+  // For the test suite. DO NOT DEPEND ON THESE!
+  export
+    program-name;
 end module command-line-parser;

--- a/library.dylan
+++ b/library.dylan
@@ -60,7 +60,8 @@ define module command-line-parser
 
   export
     <command-line-parser>,
-    positional-options,
+    positional-options,         // deprecated. not options.
+    positional-arguments,
     add-option,
     parse-command-line,
     get-option-value,

--- a/macros.dylan
+++ b/macros.dylan
@@ -33,7 +33,7 @@ copyright: See LICENSE file in this distribution.
 //             (add-dylan-keyword 'dyl-parameterized-definition-words
 //                                "command-line")
 //             (add-dylan-keyword 'dyl-other-keywords "option")
-//             (add-dylan-keyword 'dyl-other-keywords "positional-options")
+//             (add-dylan-keyword 'dyl-other-keywords "positional-arguments")
 //             (add-dylan-keyword 'dyl-other-keywords "synopsis")))
 //
 //
@@ -76,9 +76,9 @@ copyright: See LICENSE file in this distribution.
 //
 //       - Remaining keywords are handed as initargs to make.
 //
-//       - Besides ``option'' there is also ``positional-options'' and
+//       - Besides ``option'' there is also ``positional-arguments'' and
 //         ``synopsis'':
-//           positional-options file-names;
+//           positional-arguments file-names;
 //           synopsis "Usage: foo\n",
 //             description: "This program fooifies.\n";
 //
@@ -160,7 +160,7 @@ copyright: See LICENSE file in this distribution.
 //
 //  - Transform human-readable `?options' into patterns of the form
 //      [option-name, type, [default-if-any], #rest initargs]
-//      [positional-options-name]
+//      [positional-arguments-name]
 //      (usage, description)
 //
 //  - Hand it over to `defcmdline-rec'.
@@ -185,7 +185,7 @@ define macro command-line-definer
     { option ?:name :: ?value-type:expression = ?default:expression,
         #rest ?initargs:*; ... }
       => { [?name, ?value-type, [?default], ?initargs] ... }
-    { positional-options ?:name; ... }
+    { positional-arguments ?:name; ... }
       => { [?name] ... }
     { synopsis ?usage:expression, #key ?description:expression = #f; ... }
       => { (?usage, ?description) ... }
@@ -199,11 +199,11 @@ end macro;
 //   - Start out without `?processed' forms.
 //   - (Recursively) take each `?options' form and add it to ?processed,
 //     prepending it with the parser class name in the case of "option"
-//     or "positional-options" clauses. The resulting `?processed' form
+//     or "positional-arguments" clauses. The resulting `?processed' form
 //     is a sequence of the following forms:
 //       (usage, description)
 //       [class-name, option-name, value-type, [default], initargs]
-//       [class-name, positional-options-name]
+//       [class-name, positional-arguments-name]
 //   - Finally, pass the `?processed' forms to `defcmdline-aux'.
 //
 // Explanation: The options will be processed by auxiliary rules
@@ -271,7 +271,7 @@ define macro defcmdline-class
                       ?default,
                       ?initargs);
                end; ... }
-    { [?class:name, ?positional-options:name] ... }
+    { [?class:name, ?positional-arguments:name] ... }
       => {  ... }
     { (?usage:*) ... }
       => { ... }
@@ -296,7 +296,7 @@ define macro defcmdline-init
     { [?class:name, ?option:name, ?value-type:expression, [?default:*],
        ?initargs:*] ... }
       => { add-option(instance, ?option ## "-parser" (instance)); ... }
-    { [?class:name, ?positional-options:name] ... }
+    { [?class:name, ?positional-arguments:name] ... }
       => {  ... }
     { (?usage:*) ... }
       => { ... }
@@ -316,10 +316,10 @@ define macro defcmdline-accessors
              let optionparser = ?option ## "-parser" (arglistparser);
              option-value(optionparser);
            end method ?option; ... }
-    { [?class:name, ?positional-options:name] ... }
-      => { define method ?positional-options (arglistparser :: ?class)
+    { [?class:name, ?positional-arguments:name] ... }
+      => { define method ?positional-arguments (arglistparser :: ?class)
             => (value :: <sequence>);
-             positional-options(arglistparser);
+             positional-arguments(arglistparser);
            end method; ... }
     { (?usage:*) ... }
       => { ... }

--- a/tests/command-line-parser-test-suite-app-library.dylan
+++ b/tests/command-line-parser-test-suite-app-library.dylan
@@ -7,5 +7,4 @@ end library;
 
 define module command-line-parser-test-suite-app
   use testworks;
-  use command-line-parser-test-suite;
 end module;

--- a/tests/command-line-parser-test-suite-app.dylan
+++ b/tests/command-line-parser-test-suite-app.dylan
@@ -1,3 +1,3 @@
 module: command-line-parser-test-suite-app
 
-run-test-application(command-line-parser-test-suite);
+run-test-application();

--- a/tests/command-line-parser-test-suite-library.dylan
+++ b/tests/command-line-parser-test-suite-library.dylan
@@ -7,8 +7,6 @@ define library command-line-parser-test-suite
   use strings;
   use system;
   use testworks;
-
-  export command-line-parser-test-suite;
 end library;
 
 define module command-line-parser-test-suite
@@ -21,6 +19,4 @@ define module command-line-parser-test-suite
   use strings;
   use testworks;
   use threads;
-
-  export command-line-parser-test-suite;
 end module;

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -149,9 +149,9 @@ end test;
 define test test-duplicate-name-error ()
   let parser = make(<command-line-parser>);
   add-option(parser, make(<flag-option>, names: #("x")));
-  check-condition("", <command-line-parser-error>,
-                  add-option(parser, make(<flag-option>, names: #("x"))));
-end;
+  assert-signals(<command-line-parser-error>,
+                 add-option(parser, make(<flag-option>, names: #("x"))));
+end test;
 
 define test test-option-type ()
   local method make-parser ()

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -41,18 +41,19 @@ end function make-parser;
 
 define function parse (#rest argv)
   let parser = make-parser();
-  values(parser, parse-command-line(parser, argv))
-end;
+  parse-command-line(parser, argv);
+  parser
+end function;
 
 define test test-command-line-parser ()
   check-condition("blah", <usage-error>, parse("--bad-option-no-donut"));
 
   // A correct parse with all arguments specified in long format.
-  let (parser, parse-result) = parse("--verbose", "--foo",
-                                     "--quux", "quux-value",
-                                     "--optimize=optimize-value",
-                                     "--warning", "warning-value",
-                                     "--define", "key", "=", "value");
+  let parser = parse("--verbose", "--foo",
+                     "--quux", "quux-value",
+                     "--optimize=optimize-value",
+                     "--warning", "warning-value",
+                     "--define", "key", "=", "value");
   check-equal("verbose is true",
               get-option-value(parser, "verbose"),
               #t);

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -271,17 +271,3 @@ define test test-min-max-positional-options ()
   assert-signals(<usage-error>, parse-command-line(parser, #["a", "b", "c"]), "yyy");
   assert-signals(<help-requested>, parse-command-line(parser, #["-h"]));
 end test test-min-max-positional-options;
-
-define suite command-line-parser-test-suite
-  (/* setup-function: foo, cleanup-function: bar */)
-  test test-command-line-parser;
-  test test-synopsis-format;
-  test test-help-substitutions;
-  test test-usage;
-  test test-duplicate-name-error;
-  test test-option-type;
-  test test-option-default;
-  test test-choice-option;
-  test test-defcmdline;
-  test test-min-max-positional-options;
-end suite;

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -72,7 +72,7 @@ define test test-command-line-parser ()
   let defines = get-option-value(parser, "define");
   check-equal("key is defined as 'value'", defines["key"], "value");
   check-true("positional options are empty",
-             empty?(parser.positional-options));
+             empty?(parser.positional-arguments));
 end test test-command-line-parser;
 
 define test test-<parameter-option> ()
@@ -261,7 +261,7 @@ define command-line <defcmdline-test-parser> ()
   option log-filename, names: #("log", "l"),
     help: "Log file pathname",
     kind: <parameter-option>;
-  positional-options file-names;
+  positional-arguments file-names;
 end command-line;
 
 
@@ -278,13 +278,13 @@ end test test-defcmdline;
 ignore(log-filename);
 ignore(other);
 
-define test test-min-max-positional-options ()
+define test test-min-max-positional-arguments ()
   let parser = make(<command-line-parser>,
-                    min-positional-options: 1,
-                    max-positional-options: 2);
+                    min-positional-arguments: 1,
+                    max-positional-arguments: 2);
   assert-signals(<usage-error>, parse-command-line(parser, #[]), "xyz");
   assert-no-errors(parse-command-line(parser, #["a"]), "abc");
   assert-no-errors(parse-command-line(parser, #["a", "b"]), "xxx");
   assert-signals(<usage-error>, parse-command-line(parser, #["a", "b", "c"]), "yyy");
   assert-signals(<help-requested>, parse-command-line(parser, #["-h"]));
-end test test-min-max-positional-options;
+end test;

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -75,6 +75,31 @@ define test test-command-line-parser ()
              empty?(parser.positional-options));
 end test test-command-line-parser;
 
+define test test-<parameter-option> ()
+  local
+    method parse (argv)
+      let p = make(<command-line-parser>);
+      add-option(p, make(<parameter-option>, names: #("airport", "a")));
+      parse-command-line(p, argv);
+      p
+    end;
+  // I've never seen any command line parser handle '=' with spaces around it.
+  // Or maybe they do and I've just never seen it used? Should we even support
+  // that? --cgay
+  for (argv in list(vector("--airport", "BOS"),
+                    vector("--airport=BOS"),
+                    vector("--airport", "=", "BOS"),
+                    vector("-aBOS"),
+                    vector("-a=BOS"),
+                    vector("-a", "=", "BOS")))
+    let parser = parse(argv);
+    assert-equal("BOS", get-option-value(parser, "airport"),
+                 format-to-string("argv = %=", argv));
+    assert-equal("BOS", get-option-value(parser, "a"),
+                 format-to-string("argv = %=", argv));
+  end;
+end test;
+
 // This test is pretty brittle.  Would be good to make it ignore
 // whitespace to some extent.
 define test test-synopsis-format ()

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -75,6 +75,29 @@ define test test-command-line-parser ()
              empty?(parser.positional-arguments));
 end test test-command-line-parser;
 
+define test test-<flag-option> ()
+  local
+    method parse (default, argv)
+      let p = make(<command-line-parser>);
+      add-option(p, make(<flag-option>,
+                         names: #("verbose", "v"),
+                         negative-names: #("quiet", "q"),
+                         default: default));
+      parse-command-line(p, argv);
+      p
+    end;
+  assert-false(option-value(make(<flag-option>)), "boolean flag defaults to false?");
+  for (item in list(list(#f, #["--verbose"], #t),
+                    list(#t, #["--verbose"], #t),
+                    list(#f, #["-v"],        #t),
+                    list(#f, #["--quiet"],   #f),
+                    list(#t, #["--quiet"],   #f),
+                    list(#f, #["-q"],        #f)))
+    let (default, argv, want) = apply(values, item);
+    assert-equal(want, get-option-value(parse(default, argv), "verbose"), item);
+  end;
+end test;
+
 define test test-<parameter-option> ()
   local
     method parse (argv)

--- a/tests/command-line-parser-test-suite.dylan
+++ b/tests/command-line-parser-test-suite.dylan
@@ -2,15 +2,6 @@ module: command-line-parser-test-suite
 synopsis: Test suite for the command-line-parser  library.
 copyright: See LICENSE file in this distribution.
 
-// Modified by Carl Gay to use the testworks library and to test
-// defcmdline.  Moved from src/tests to libraries/getopt/tests.
-// 2006.11.29
-
-// Now in libraries/utilities/command-line-parser/tests
-// Hannes Mehnert 2007.02.23
-
-// Now in it's own github repo.  cgay ~2011
-
 // TODO(cgay): Suppress output to stderr from usage errors in tests.
 
 
@@ -109,7 +100,7 @@ define test test-help-substitutions ()
                     default: #t,
                     help: "%%%default%%prog%");
   check-equal("", "%#t%prog%", option.option-help);
-end;  
+end;
 
 // Verify that the usage: and description: passed to parse-command-line
 // are displayed correctly.

--- a/tests/command-line-parser-test-suite.lid
+++ b/tests/command-line-parser-test-suite.lid
@@ -1,4 +1,5 @@
 library: command-line-parser-test-suite
 target-type: dll
 files: command-line-parser-test-suite-library
+       options-test
        command-line-parser-test-suite

--- a/tests/options-test.dylan
+++ b/tests/options-test.dylan
@@ -1,0 +1,181 @@
+Module: command-line-parser-test-suite
+
+define method parse-one (option, argv)
+  let p = make(<command-line-parser>,
+               help: "x",
+               options: list(option));
+  parse-command-line(p, argv);
+  p
+end;
+
+define test test-flag-option ()
+  assert-false(option-value(make(<flag-option>, name: "x", help: "x")),
+               "boolean flag defaults to false?");
+  local
+    method parse (default, argv)
+      let p = make(<command-line-parser>,
+                   help: "x",
+                   options: list(make(<flag-option>,
+                                      names: #("verbose", "v"),
+                                      help: "x",
+                                      negative-names: #("quiet", "q"),
+                                      default: default)));
+      parse-command-line(p, argv);
+      p
+    end;
+  for (item in list(/* list(#f, #["--verbose"], #t),
+                    list(#t, #["--verbose"], #t),
+                    list(#f, #["-v"],        #t),
+                    list(#f, #["--quiet"],   #f), */
+                    list(#t, #["--quiet"],   #f) /* ,
+                    list(#f, #["-q"],        #f) */ ))
+    let (default, argv, want) = apply(values, item);
+    assert-equal(want,
+                 get-option-value(parse(default, argv), "verbose"),
+                 item);
+  end;
+end test;
+
+define test test-parameter-option ()
+  local
+    method parse (argv)
+      let p = make(<command-line-parser>, help: "x");
+      add-option(p, make(<parameter-option>,
+                         names: #("airport", "a"),
+                         help: "x"));
+      parse-command-line(p, argv);
+      p
+    end;
+  // I've never seen any command line parser handle '=' with spaces around it.
+  // Or maybe they do and I've just never seen it used? Should we even support
+  // that? --cgay
+  for (argv in list(vector("--airport", "BOS"),
+                    vector("--airport=BOS"),
+                    vector("--airport", "=", "BOS"),
+                    vector("-aBOS"),
+                    vector("-a=BOS"),
+                    vector("-a", "=", "BOS")))
+    let parser = parse(argv);
+    assert-equal("BOS", get-option-value(parser, "airport"),
+                 format-to-string("argv = %=", argv));
+    assert-equal("BOS", get-option-value(parser, "a"),
+                 format-to-string("argv = %=", argv));
+  end;
+end test;
+
+define test test-keyed-option ()
+end;
+
+define test test-repeated-parameter-option ()
+end;
+
+define test test-optional-parameter-option ()
+end;
+
+define test test-choice-option ()
+  let name = "choice";
+  local method opt (default)
+          make(<choice-option>,
+               name: name,
+               choices: list("a", "b", "c"),
+               default: default,
+               help: "-")
+        end;
+  assert-equal("a",
+               get-option-value(parse-one(opt("b"), #["--choice", "a"]), name),
+               "valid value parses correctly");
+  assert-signals(<usage-error>,
+                 parse-one(opt("b"), #["--choice", "x"]),
+                 "invalid value signals <usage-error>");
+  assert-equal("b",
+               get-option-value(parse-one(opt("b"), #[]), name),
+               "default value is correct");
+
+  // In general (for all options) we don't enforce that the default value must
+  // be part of the option.option-type type, primarily so that they can default
+  // to #f.
+  assert-no-errors(make(<parameter-option>,
+                        names: "n",
+                        type: <integer>,
+                        default: #f, // testing this doesn't signal
+                        help: "h"));
+end test;
+
+define class <subcommand-a> (<subcommand>) end;
+
+define test test-positional-option-validation ()
+  let required-a = make(<positional-option>,
+                        names: "a", help: "h", required?: #t, repeated?: #f);
+  let required-b = make(<positional-option>,
+                        names: "b", help: "h", required?: #t, repeated?: #f);
+  let optional-c = make(<positional-option>,
+                        names: "c", help: "h", required?: #f, repeated?: #f);
+  let optional-d = make(<positional-option>,
+                        names: "d", help: "h", required?: #f, repeated?: #f);
+  let required-repeated-e = make(<positional-option>,
+                                 names: "e", help: "h", required?: #t, repeated?: #t);
+  let optional-repeated-f = make(<positional-option>,
+                                 names: "e", help: "h", required?: #f, repeated?: #t);
+  let flag = make(<flag-option>, names: "flag", help: "h");
+
+  let valid-cases = list(list(flag, required-a, required-b),
+                         list(required-a, optional-c),
+                         list(required-a, optional-c, optional-d),
+                         list(required-a, optional-c, optional-repeated-f),
+                         list(optional-c, optional-d),
+                         list(optional-repeated-f),
+                         list(required-repeated-e));
+  for (opts in valid-cases)
+    assert-no-errors(make(<command-line-parser>, help: "h", options: opts),
+                     format-to-string("valid case %=", opts));
+    assert-no-errors(make(<subcommand-a>, name: "sub", help: "h", options: opts),
+                     format-to-string("valid case (subcommand) %=", opts));
+  end;
+
+  let error-cases = list(list(optional-c, required-a),
+                         list(required-repeated-e, required-a),
+                         list(optional-repeated-f, required-a),
+                         list(optional-repeated-f, required-a),
+                         list(optional-repeated-f, optional-c));
+  for (opts in error-cases)
+    assert-signals(<command-line-parser-error>,
+                   make(<command-line-parser>, help: "h", options: opts),
+                   format-to-string("error case %=", opts));
+    assert-signals(<command-line-parser-error>,
+                   make(<subcommand-a>, name: "sub", help: "h", options: opts),
+                   format-to-string("error case (subcommand) %=", opts));
+  end;
+
+  // Subcommands and positionals can't be added to the top-level parser.
+  let sub = make(<subcommand-a>, help: "h", name: "a");
+  assert-signals(<command-line-parser-error>,
+                 make(<command-line-parser>,
+                      help: "h",
+                      options: list(required-a),
+                      subcommands: list(sub)),
+                 "subcommands and required positionals");
+  assert-signals(<command-line-parser-error>,
+                 make(<command-line-parser>,
+                      help: "h",
+                      options: list(optional-c),
+                      subcommands: list(sub)),
+                 "subcommands and optional positionals");
+end test;
+
+define test test-positional-option-parsing ()
+  let p1 = make(<positional-option>, names: "p1", help: "h", required?: #t);
+  let p2 = make(<positional-option>, names: "p2", help: "h", required?: #t);
+  let p3 = make(<positional-option>, names: "p3", help: "h", required?: #f);
+  let p4 = make(<positional-option>, names: "p4", help: "h", required?: #f);
+  let p5 = make(<positional-option>, names: "p5", help: "h", required?: #f, repeated?: #t);
+  let cmd = make(<command-line-parser>,
+                 help: "h",
+                 options: list(make(<flag-option>, names: "flag", help: "h"),
+                               p1, p2, p3, p4, p5));
+  assert-no-errors(parse-command-line(cmd, #["a", "b", "c", "d", "e", "f"]));
+  assert-equal("a", p1.option-value);
+  assert-equal("b", p2.option-value);
+  assert-equal("c", p3.option-value);
+  assert-equal("d", p4.option-value);
+  assert-equal(#["e", "f"], p5.option-value);
+end test;


### PR DESCRIPTION
Docs are [here](https://github.com/dylan-lang/opendylan/pull/1382).

* Added support for subcommands
* Added `<positional-option>` as a way to handle positional arguments just like pass-by-name arguments. The command line can now be fully described and the "usage" line is fully auto-generated.

See doc for details.

I must admit that at some point there were so many changes I stopped trying to keep it minimal...

The main remaining TODO is to add support for subcommands to the `define command-line` macro.