### PR TITLE
docs: Use toctree instead of contents, more...

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -1,78 +1,18 @@
 # Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import os
 import sys
-
-sys.path.insert(0, os.path.abspath('../sphinx-extensions/sphinxcontrib'))
-
-import dylan.domain
-import dylan.themes as dylan_themes
-
-
-
-# -- Project information -----------------------------------------------------
+sys.path.insert(0, os.path.abspath('../../_packages/sphinx-extensions/current/src/sphinxcontrib'))
 
 project = 'command-line-parser'
 copyright = '2022, Dylan Hackers'
 author = 'Dylan Hackers'
-
-# The full version, including alpha/beta/rc tags
 release = 'v3.2.0'
-
-
-# -- General configuration ---------------------------------------------------
-
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
+exclude_patterns = ['_build']
+primary_domain = 'dylan'
+html_theme = 'furo'             # sudo pip install furo
+html_title = 'command-line-parser'
 extensions = [
     'dylan.domain',
     'sphinx.ext.intersphinx'
 ]
-
-# Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
-
-# List of patterns, relative to source directory, that match files and
-# directories to ignore when looking for source files.
-# This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build']
-
-# This makes it so that each document doesn't have to use
-#   .. default-domain:: dylan
-# but they probably should anyway, so that they can be built separately
-# without depending on this top-level config file.
-primary_domain = 'dylan'
-
-# -- Options for HTML output -------------------------------------------------
-
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-html_theme = dylan_themes.get_html_theme_default()
-
-# Theme options are theme-specific and customize the look and feel of a theme
-# further.  For a list of options available for each theme, see the
-# documentation.
-html_theme_options = dylan_themes.get_html_theme_options_default()
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [dylan_themes.get_html_theme_path()]
-
-# The name for this set of Sphinx documents.  If None, it defaults to
-# "<project> v<release> documentation".
-html_title = "Dylan Library Reference"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -1,12 +1,11 @@
-*******************************
-The command-line-parser Library
-*******************************
+*******************
+command-line-parser
+*******************
 
 .. current-library:: command-line-parser
 .. current-module:: command-line-parser
 
-.. contents::  Contents
-   :local:
+.. toctree::
 
 
 The *command-line-parser* library provides a facility to parse the
@@ -151,8 +150,8 @@ Reference
 =========
 
 
-The command-line-parser Module
-------------------------------
+Module: command-line-parser
+---------------------------
 
 .. class:: <command>
    :abstract:
@@ -714,8 +713,8 @@ Option Classes
       of the default one.
 
 
-The option-parser-protocol Module
----------------------------------
+Module: option-parser-protocol
+------------------------------
 
 This module exports an API that can be used to extend the existing command line
 parser without modifying the source in this library.  It shouldn't be common to

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -10,6 +10,7 @@
         "strings@1.0"
     ],
     "dev-dependencies": [
+        "sphinx-extensions",
         "testworks@2.0"
     ]
 }


### PR DESCRIPTION
The `.. contents::` directive doesn't play well with Furo theme. This change won't show up on opendylan.org package docs until a new version of the package is published.

* Reduce conf.py to minimal settings with furo theme.
* Add sphinx-extensions as dev dependency and have conf.py use relative path to it via _packages directory.
* Make major headings less wordy.