### PR TITLE
[doc] Fix broken link to documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## command-line-parser
 
 This library is documented as part of the Open Dylan Library Reference:
-https://opendylan.org/documentation/library-reference/command-line-parser/index.html
+https://opendylan.org/package/command-line-parser/


### PR DESCRIPTION
Fix #39