### PR TITLE
ci: Divide build and check documentation from deploy

### DIFF
--- a/.github/workflows/build-and-check-documentation.yml
+++ b/.github/workflows/build-and-check-documentation.yml
@@ -1,7 +1,7 @@
-name: Build and deploy documentation
+name: Build and check documentation
 
 on:
-  push:
+  pull_request:
     # all branches
     paths:
       - 'documentation/**'


### PR DESCRIPTION
Create a new GH Action ('build-and-check-documentation.yml') that build the docs and check the links, but don't deploy on Pull Requests since the action has no permission to do it.

On Push, the action 'build-and-deploy-documentation' will build, check the links and deploy the HTML files on GH pages.