### PR TITLE
Better handling of "--"

### DIFF
--- a/library.dylan
+++ b/library.dylan
@@ -70,6 +70,7 @@ define module command-line-parser
     parse-command-line,
     get-option-value,
     print-help,
+    unconsumed-arguments,
 
     parse-option-value;
 

--- a/tests/options-test.dylan
+++ b/tests/options-test.dylan
@@ -217,3 +217,20 @@ define test test-positional-option-parsing ()
   assert-equal("d", p4.option-value);
   assert-equal(#["e", "f"], p5.option-value);
 end test;
+
+define test test-unconsumed-arguments ()
+  let p1 = make(<positional-option>, name: "p1", help: "?", required?: #f);
+  let cmd1 = make(<command-line-parser>, help: "?", options: list(p1));
+  assert-no-errors(parse-command-line(cmd1, #["x", "--", "y", "z"]));
+  assert-equal(#["y", "z"], cmd1.unconsumed-arguments);
+  assert-no-errors(parse-command-line(cmd1, #["--", "y", "z"]));
+  assert-equal(#["y", "z"], cmd1.unconsumed-arguments);
+
+  // Same assertions but with the final positional option allowing more than one arg.
+  let p2 = make(<positional-option>, name: "p1", help: "?", required?: #f, repeated?: #t);
+  let cmd2 = make(<command-line-parser>, help: "?", options: list(p2));
+  assert-no-errors(parse-command-line(cmd2, #["x", "--", "y", "z"]));
+  assert-equal(#["y", "z"], cmd2.unconsumed-arguments);
+  assert-no-errors(parse-command-line(cmd2, #["--", "y", "z"]));
+  assert-equal(#["y", "z"], cmd2.unconsumed-arguments);
+end test;


### PR DESCRIPTION
This is the simplest fix I could see for the second part ("Also, and more importantly...") of #47 ... simply stuff everything after "--" into a new `unconsumed-arguments` slot in the parser.

While technically this creates a backward incompatibility, the old code resulted in all the arguments being added to the final option's value list **in reverse order** and it is highly unlikely that anyone is depending on that broken behavior.

(This should be enough to allow me to make progress on the `deft test` command, in which I want to be able to pass extra args to testworks with `deft test --build --all -- ...testworks-options...`.)