### PR TITLE
package: bump version from 3.2.1 -> 3.2.2

### DIFF
--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,7 +1,7 @@
 {
     "name": "command-line-parser",
     "description": "Parse command line flags and subcommands",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "url": "https://github.com/dylan-lang/command-line-parser",
     "category": "utilities",
     "contact": "dylan-lang@googlegroups.com",


### PR DESCRIPTION
Want to get a published version with the fix for `--` handling.